### PR TITLE
BUG: Status not explicitly updated

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -191,6 +191,12 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 			$wpdb->query($sqlQuery);
 			$membership_in_the_past = true;
 		}
+		
+		if($membership_status === "active" && (empty($membership_enddate) || $membership_enddate === "NULL" || strtotime($membership_enddate, current_time('timestamp')) >= current_time('timestamp')))
+		{			
+			$sqlQuery = $wpdb->prepare("UPDATE {$wpdb->pmpro_memberships_users} SET status = 'active' WHERE user_id = %d AND membership_id = %d", $user_id, $membership_id);		
+			$wpdb->query($sqlQuery);
+		}
 	}
 	
 	//look for a subscription transaction id and gateway


### PR DESCRIPTION
With the updates to pmpro_changeMembershipLevel() for MMPU, if the user specified membership_status during import, we'd always set it to 'inactive' (default value for pmpro_changeMembershipLevel()).