### PR TITLE
This commit fixes #15

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -207,7 +207,8 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 		
 	//add order so integration with gateway works
 	if(
-		!empty($membership_subscription_transaction_id) && !empty($membership_gateway) ||
+// 		!empty($membership_subscription_transaction_id) && 
+		!empty($membership_gateway) ||
 		!empty($membership_timestamp) || !empty($membership_code_id)
 	)
 	{


### PR DESCRIPTION
I removed the condition which checks if `$membership_subscription_transaction_id` is empty, because not all orders are recurring. 
This change enables the script to automatically create the corresponding order, even when the `subscription_transaction_id` is missing.