### PR TITLE
Supress change membership level option added

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -205,7 +205,13 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 	}	
 
 	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) )
-		$membership_code_id = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_discount_codes WHERE `code` = '" . esc_sql($membership_discount_code) . "' LIMIT 1");		
+		$membership_code_id = $wpdb->get_var(
+			$wpdb->prepare( "
+				SELECT id
+				FROM $wpdb->pmpro_discount_codes
+				WHERE `code` = %s
+				LIMIT 1
+			", $membership_discount_code );
 	
 	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ! empty( $_REQUEST['supress_change_membership_hooks'] ) ){
 		//We're assuming they've already been imported with this level, so don't do it again

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -370,7 +370,8 @@ function pmproiufcsv_add_import_options(){
 
 				<label for="supress_change_membership_hooks">
 					<input id="supress_change_membership_hooks" name="supress_change_membership_hooks" type="checkbox" value="1" />
-					<?php _e( 'Supress change membership level hooks during import?', 'pmpro-import-users-from-csv' ) ;?>
+					<?php esc_html_e( 'Supress change membership level hooks during import?', 'pmpro-import-users-from-csv' ) ;?>
+
 				</label>
 			</fieldset>
 		</td>

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -358,8 +358,12 @@ function pmproiufcsv_plugin_row_meta($links, $file) {
 }
 add_filter('plugin_row_meta', 'pmproiufcsv_plugin_row_meta', 10, 2);
 
-
-function pmproiufcsv_add_import_options(){
+/**
+ * Render the additional options for the Import Users from CSV plugin settings page.
+ *
+ * @since TBD
+ */
+function pmproiufcsv_add_import_options() {
 
 	?>
 

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -202,25 +202,22 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 
 	if ( ! empty( $membership_timestamp ) ) {
 		$membership_timestamp = date( 'Y-m-d', strtotime($membership_timestamp, current_time( 'timestamp' ) ) );
-	}	
+	}
 
-	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) )
+	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) ) {
 		$membership_code_id = $wpdb->get_var(
 			$wpdb->prepare( "
 				SELECT id
 				FROM $wpdb->pmpro_discount_codes
 				WHERE `code` = %s
 				LIMIT 1
-			", $membership_discount_code );
-	
-	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ! empty( $_REQUEST['supress_change_membership_hooks'] ) ){
-		//We're assuming they've already been imported with this level, so don't do it again
+			", $membership_discount_code )
+		);
+	}
+
+	// Check whether the member may already have been imported.
+	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ! empty( $_REQUEST['suppress_change_membership_hooks'] ) ){
 		return;
-	} 
-	
-	//look up discount code
-	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) ) {
-		$membership_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE `code` = '" . esc_sql( $membership_discount_code ) . "' LIMIT 1" );		
 	}
 	
 	//look for a subscription transaction id and gateway
@@ -367,16 +364,16 @@ function pmproiufcsv_add_import_options(){
 	?>
 
 	<tr valign="top">
-		<td scope="row"><strong><?php esc_html_e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
+		<td scope="row"><strong><?php esc_html_e( 'Suppress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
 
 		<td>
 			<fieldset>
-				<legend class="screen-reader-text"><span><?php esc_html_e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>
+				<legend class="screen-reader-text"><span><?php esc_html_e( 'Suppress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>
 
 
-				<label for="supress_change_membership_hooks">
-					<input id="supress_change_membership_hooks" name="supress_change_membership_hooks" type="checkbox" value="1" />
-					<?php esc_html_e( 'Supress change membership level hooks during import?', 'pmpro-import-users-from-csv' ) ;?>
+				<label for="suppress_change_membership_hooks">
+					<input id="suppress_change_membership_hooks" name="suppress_change_membership_hooks" type="checkbox" value="1" />
+					<?php esc_html_e( 'Suppress change membership level hooks during import?', 'pmpro-import-users-from-csv' ) ;?>
 
 				</label>
 			</fieldset>

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -188,7 +188,12 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 	//look up discount code
 	if(!empty($membership_discount_code) && empty($membership_code_id))
 		$membership_code_id = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_discount_codes WHERE `code` = '" . esc_sql($membership_discount_code) . "' LIMIT 1");		
-		
+	
+	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ( !empty( $_REQUEST['supress_change_membership_hooks'] ) && $_REQUEST['supress_change_membership_hooks'] == '1' ) ){
+		//We're assuming they've already been imported with this level, so don't do it again
+		return;
+	} 
+	
 	//change membership level
 	if(!empty($membership_id))
 	{
@@ -298,3 +303,27 @@ function pmproiufcsv_plugin_row_meta($links, $file) {
 	return $links;
 }
 add_filter('plugin_row_meta', 'pmproiufcsv_plugin_row_meta', 10, 2);
+
+
+function pmproiufcsv_add_import_options(){
+
+	?>
+
+	<tr valign="top">
+		<td scope="row"><strong><?php _e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
+		<td>
+			<fieldset>
+				<legend class="screen-reader-text"><span><?php _e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>
+
+				<label for="supress_change_membership_hooks">
+					<input id="supress_change_membership_hooks" name="supress_change_membership_hooks" type="checkbox" value="1" />
+					<?php _e( 'Supress change membership level hooks during import?', 'pmpro-import-users-from-csv' ) ;?>
+				</label>
+			</fieldset>
+		</td>
+	</tr>
+
+	<?php
+
+}
+add_action( 'is_iu_import_page_inside_table_bottom', 'pmproiufcsv_add_import_options' );

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -368,16 +368,16 @@ function pmproiufcsv_add_import_options() {
 	?>
 
 	<tr valign="top">
-		<td scope="row"><strong><?php esc_html_e( 'Skip importing users that already have the same level?' , 'pmpro-import-users-from-csv'); ?></strong></td>
+		<td scope="row"><strong><?php esc_html_e( 'Skip existing members' , 'pmpro-import-users-from-csv'); ?></strong></td>
 
 		<td>
 			<fieldset>
-				<legend class="screen-reader-text"><span><?php esc_html_e( 'Skip importing users that already have the same level?' , 'pmpro-import-users-from-csv' ); ?></span></legend>
+				<legend class="screen-reader-text"><span><?php esc_html_e( 'Skip existing members' , 'pmpro-import-users-from-csv' ); ?></span></legend>
 
 
 				<label for="skip_existing_members_same_level">
 					<input id="skip_existing_members_same_level" name="skip_existing_members_same_level" type="checkbox" value="1" />
-					<?php esc_html_e( 'Skip importing users if they already have the same membership level as the membership_id in the CSV?', 'pmpro-import-users-from-csv' ) ;?>
+					<?php esc_html_e( 'Do not change membership level of user if they already have the same membership_id level during import', 'pmpro-import-users-from-csv' ) ;?>
 
 				</label>
 			</fieldset>

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -216,7 +216,7 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 	}
 
 	// Check whether the member may already have been imported.
-	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ! empty( $_REQUEST['suppress_change_membership_hooks'] ) ){
+	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ! empty( $_REQUEST['skip_existing_members_same_level'] ) ){
 		return;
 	}
 	
@@ -361,23 +361,23 @@ add_filter('plugin_row_meta', 'pmproiufcsv_plugin_row_meta', 10, 2);
 /**
  * Render the additional options for the Import Users from CSV plugin settings page.
  *
- * @since TBD
+ * @since 0.4
  */
 function pmproiufcsv_add_import_options() {
 
 	?>
 
 	<tr valign="top">
-		<td scope="row"><strong><?php esc_html_e( 'Suppress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
+		<td scope="row"><strong><?php esc_html_e( 'Skip importing users that already have the same level?' , 'pmpro-import-users-from-csv'); ?></strong></td>
 
 		<td>
 			<fieldset>
-				<legend class="screen-reader-text"><span><?php esc_html_e( 'Suppress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>
+				<legend class="screen-reader-text"><span><?php esc_html_e( 'Skip importing users that already have the same level?' , 'pmpro-import-users-from-csv' ); ?></span></legend>
 
 
-				<label for="suppress_change_membership_hooks">
-					<input id="suppress_change_membership_hooks" name="suppress_change_membership_hooks" type="checkbox" value="1" />
-					<?php esc_html_e( 'Suppress change membership level hooks during import?', 'pmpro-import-users-from-csv' ) ;?>
+				<label for="skip_existing_members_same_level">
+					<input id="skip_existing_members_same_level" name="skip_existing_members_same_level" type="checkbox" value="1" />
+					<?php esc_html_e( 'Skip importing users if they already have the same membership level as the membership_id in the CSV?', 'pmpro-import-users-from-csv' ) ;?>
 
 				</label>
 			</fieldset>

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -207,7 +207,7 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) )
 		$membership_code_id = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_discount_codes WHERE `code` = '" . esc_sql($membership_discount_code) . "' LIMIT 1");		
 	
-	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ( !empty( $_REQUEST['supress_change_membership_hooks'] ) && $_REQUEST['supress_change_membership_hooks'] == '1' ) ){
+	if( pmpro_hasMembershipLevel( $membership_id, $user_id ) && ! empty( $_REQUEST['supress_change_membership_hooks'] ) ){
 		//We're assuming they've already been imported with this level, so don't do it again
 		return;
 	} 

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -364,7 +364,8 @@ function pmproiufcsv_add_import_options(){
 		<td scope="row"><strong><?php _e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
 		<td>
 			<fieldset>
-				<legend class="screen-reader-text"><span><?php _e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>
+				<legend class="screen-reader-text"><span><?php esc_html_e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>
+
 
 				<label for="supress_change_membership_hooks">
 					<input id="supress_change_membership_hooks" name="supress_change_membership_hooks" type="checkbox" value="1" />

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -361,7 +361,8 @@ function pmproiufcsv_add_import_options(){
 	?>
 
 	<tr valign="top">
-		<td scope="row"><strong><?php _e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
+		<td scope="row"><strong><?php esc_html_e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv'); ?></strong></td>
+
 		<td>
 			<fieldset>
 				<legend class="screen-reader-text"><span><?php esc_html_e( 'Supress Change Membership Level Hooks' , 'pmpro-import-users-from-csv' ); ?></span></legend>


### PR DESCRIPTION
Needs some discussion though. Could also do this (might be better) but we don't hook much into the before and after actions in the core plugin

```
if( !empty( $_REQUEST['supress_change'] ) && $_REQUEST['supress_change'] == '1' ){
			remove_action("pmpro_after_change_membership_level", "pmpro_report_memberships_delete_transients");
		}
```