### PR TITLE
ENHANCEMENT: Prevent subscriptions from accidentally being cancelled.

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -140,6 +140,17 @@ function pmproiufcsv_is_iu_pre_user_import($userdata, $usermeta) {
 			delete_user_meta($user->ID, "import_" . $field);
 		}
 	}
+
+	/**
+	 * Filter to allow cancellation of subscriptions during import.
+	 * 
+	 * @since TBD
+	 * @param boolean $allow_sub_cancellations Set this option to true if you want to let subscriptions cancel on the gateway level during import.
+	 */
+	if ( ! apply_filters( 'pmproiufcsv_cancel_prev_sub_on_import', false ) ) {
+		add_filter( 'pmpro_cancel_previous_subscriptions', '__return_false' );
+	}
+	
 }
 add_action('is_iu_pre_user_import', 'pmproiufcsv_is_iu_pre_user_import', 10, 2);
 


### PR DESCRIPTION
ENHANCEMENT: Prevent subscriptions from accidentally being cancelled.

Adds a new filter `pmproiufcsv_cancel_prev_sub_on_import`. This is off by default to prevent user's from cancelling subs without knowing it. Follows similar principles to the edit user cancel sub at gateway logic.

Turns the filter on right before import.

**Note:** This will help re-imports of same data/level information and will allow user's to run multiple imports and keep the subscription active. Developer's should set this to true should they need to remove subscriptions on the gateway level when importing/changing levels.

(i.e. Change level 1 to level 2 and cancel any future payments.)

Reference: https://github.com/strangerstudios/pmpro-import-users-from-csv/issues/21