### PR TITLE
Removing unnecessary code comment; removed option to send a welcome e…

### DIFF
--- a/includes/pmpro-membership-data.php
+++ b/includes/pmpro-membership-data.php
@@ -1,49 +1,7 @@
 <?php
-/*
-	Copyright 2011	Stranger Studios	(email : jason@strangerstudios.com)
-	GPLv2 Full license details in license.txt
-
-	You should have both the Import Users From CSV and Paid Memberships Pro plugins installed and activated before using this plugin.
-
-	1. Activate Plugin
-	2. Add the usual columns to your import CSV: user_login, user_email, first_name, last_name, etc.
-	3. Add the following columns to your import CSV. * = required for membership level, ** = required for gateway subscription
-		- membership_id * (id of the membership level)
-		- membership_code_id (or use membership_discount_code if you know the code string, but not the code id #)
-		- membership_initial_payment
-		- membership_billing_amount
-		- membership_cycle_number
-		- membership_cycle_period
-		- membership_billing_limit
-		- membership_trial_amount
-		- membership_trial_limit
-		- membership_status
-		- membership_startdate
-		- membership_enddate
-		- membership_subscription_transaction_id ** (subscription transaction id or customer id from the gateway)
-		- membership_gateway ** (gateway = check, stripe, paypalstandard, paypalexpress, paypal (for website payments pro), payflowpro, authorizenet, braintree)
-		- membership_payment_transaction_id
-		- membership_affiliate_id
-		- membership_order_status (PayPal order status)
-		- membership_timestamp
-	4. Go to Users --> Import From CSV. Browse to CSV file and import.
-		- pmpro_stripe_customerid (for Stripe users, will be same as membership_subscription_transaction_id above)
-    5. (Optional) Send a welcome email by setting the global $pmproiufcsv_email. See example below.
-	6. Go to Users --> Import From CSV. Browse to CSV file and import.
-
-    Copy these lines to your active theme's functions.php or custom plugin and modify as desired to send a welcome email to members after import:
-
-    global $pmproiufcsv_email;
-    $pmproiufcsv_email = array(
-        'subject'   => sprintf('Welcome to %s', get_bloginfo('sitename')), //email subject, "Welcome to Sitename"
-        'body'      => 'Your welcome email body text will go here.'        //email body
-    );
-*/
-
-/*
-	Get list of PMPro-related fields
-*/
-/// Done.
+/**
+ * Get list of PMPro-related fields.
+ */
 function pmproiufcsv_getFields() {
 	$pmpro_fields = array(
 		"membership_id",
@@ -70,10 +28,9 @@ function pmproiufcsv_getFields() {
 	return $pmpro_fields;
 }
 
-/*
-	Delete all import_ meta fields before an import in case the user has been imported in the past.
-*/
-/// Done.
+/**
+ * Delete all import_ meta fields before an import in case the user has been imported in the past.
+ */
 function pmproiufcsv_is_iu_pre_user_import( $userdata, $usermeta, $user ) {
 	
 	if(!empty($user)) {
@@ -87,7 +44,7 @@ function pmproiufcsv_is_iu_pre_user_import( $userdata, $usermeta, $user ) {
 	/**
 	 * Filter to allow cancellation of subscriptions during import.
 	 * 
-	 * @since TBD
+	 * @since 0.4
 	 * @param boolean $allow_sub_cancellations Set this option to true if you want to let subscriptions cancel on the gateway level during import.
 	 */
 	if ( ! apply_filters( 'pmproiufcsv_cancel_prev_sub_on_import', false ) ) {
@@ -97,9 +54,9 @@ function pmproiufcsv_is_iu_pre_user_import( $userdata, $usermeta, $user ) {
 }
 add_action( 'pmproiucsv_pre_user_import', 'pmproiufcsv_is_iu_pre_user_import', 10, 3 );
 
-/*
-	Change some of the imported columns to add "imported_" to the front so we don't confuse the data later.
-*/
+/**
+ * Change some of the imported columns to add "imported_" to the front so we don't confuse the data later.
+ */
 function pmproiufcsv_is_iu_import_usermeta($usermeta, $userdata)
 {
 	$pmpro_fields = pmproiufcsv_getFields();
@@ -117,15 +74,17 @@ function pmproiufcsv_is_iu_import_usermeta($usermeta, $userdata)
 }
 add_filter("pmproiucsv_import_usermeta", "pmproiufcsv_is_iu_import_usermeta", 10, 2);
 
-//after users are added, let's use the meta data imported to update the user
+/**
+ * After users are added, let's use the meta data imported to update the user.
+ */
 function pmproiufcsv_is_iu_post_user_import($user_id)
 {
-    global $pmproiufcsv_email, $wpdb;
+    global $wpdb;
 
 	wp_cache_delete($user_id, 'users');
 	$user = get_userdata($user_id);
 
-	//look for a membership level and other information
+	// Look for a membership level and other information.
 	$membership_id = $user->import_membership_id;
 	$membership_code_id = $user->import_membership_code_id;
 	$membership_discount_code = $user->import_membership_discount_code;
@@ -141,7 +100,7 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 	$membership_enddate = $user->import_membership_enddate;
 	$membership_timestamp = $user->import_membership_timestamp;
 
-	//fix date formats
+	// Fix date formats.
 	if ( ! empty( $membership_startdate ) ) {
 		$membership_startdate = date( 'Y-m-d', strtotime( $membership_startdate, current_time( 'timestamp' ) ) );
 	} else {
@@ -174,12 +133,12 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 		return;
   }
 
-	//look up discount code
+	// Look up discount code.
 	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) ) {
 		$membership_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE `code` = '" . esc_sql( $membership_discount_code ) . "' LIMIT 1" );
 	}
 
-	//look for a subscription transaction id and gateway
+	// Look for a subscription transaction id and gateway.
 	$membership_subscription_transaction_id = $user->import_membership_subscription_transaction_id;
 	$membership_payment_transaction_id = $user->import_membership_payment_transaction_id;
 	$membership_order_status = $user->import_membership_order_status;
@@ -195,7 +154,7 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 	}
 
 
-	//change membership level
+	// Change membership level.
 	if(!empty($membership_id))
 	{
 		$custom_level = array(
@@ -216,7 +175,7 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 
 		pmpro_changeMembershipLevel($custom_level, $user_id);
 
-		//if membership was in the past make it inactive
+		// If membership was in the past make it inactive.
 		if($membership_status === "inactive" || (!empty($membership_enddate) && $membership_enddate !== "NULL" && strtotime($membership_enddate, current_time('timestamp')) < current_time('timestamp')))
 		{
 			$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users SET status = 'inactive' WHERE user_id = '" . $user_id . "' AND membership_id = '" . $membership_id . "'";
@@ -231,9 +190,8 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 		}
 	}
 
-	//add order so integration with gateway works
+	// Add order so integration with gateway works.
 	if(
-// 		!empty($membership_subscription_transaction_id) &&
 		!empty($membership_gateway) ||
 		!empty($membership_timestamp) || !empty($membership_code_id)
 	)
@@ -257,7 +215,7 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 
 		$order->saveOrder();
 
-		//update timestamp of order?
+		// Maybe update timestamp of order.
 		if(!empty($membership_timestamp))
 		{
 			$timestamp = strtotime($membership_timestamp, current_time('timestamp'));
@@ -265,27 +223,17 @@ function pmproiufcsv_is_iu_post_user_import($user_id)
 		}
 	}
 
-	//add code use
+	// Add code use.
 	if(!empty($membership_code_id) && !empty($order) && !empty($order->id))
 		$wpdb->query("INSERT INTO $wpdb->pmpro_discount_codes_uses (code_id, user_id, order_id, timestamp) VALUES('" . esc_sql($membership_code_id) . "', '" . esc_sql($user_id) . "', '" . intval($order->id) . "', now())");
 
-	//email user if global is set
-    if(!empty($pmproiufcsv_email))
-    {
-        $email = new PMProEmail();
-        $email->email = $user->user_email;
-        $email->subject = $pmproiufcsv_email['subject'];
-        $email->body = $pmproiufcsv_email['body'];
-        $email->template = 'pmproiufcsv';
-        $email->sendEmail();
-    }
 }
 add_action("pmproiucsv_post_user_import", "pmproiufcsv_is_iu_post_user_import");
 
 /**
  * Add error/warning message if user's were imported with both a subscription and expiration date.
  *
- * @since TBD
+ * @since 0.4
  *
  * @param array $errors An array of various error messages.
  * @param [type] $user_ids
@@ -320,12 +268,12 @@ function pmproiufcsv_add_import_options() { ?>
 		</td>
 	</tr>
 	<?php
-
 }
 add_action( 'pmproiucsv_import_page_inside_table_bottom', 'pmproiufcsv_add_import_options' );
 
 /**
  * Required headers when importing members that shows a notice if it's missing.
+ *
  * @since 1.0
  */
 function pmproiucsv_required_pmpro_import_headers( $required_headers ) {


### PR DESCRIPTION
…mail to members after import (create a gist instead)

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-import-users-from-csv/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-import-users-from-csv/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Removed a big code comment that wasn't necessary or accurate.
2. Removed the global you can define to send a welcome email to members after import. We will use a gist in favor of this natively in the Add On.
3. Removed an uncommented line of code that Jason was going to remove from a 2019 PR merge but was still in there.
