### PR TITLE
Skips custom fields when the value is empty

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -625,6 +625,11 @@ class PMPro_Import_Users_From_CSV {
 				// If no error, let's update the user meta too!
 				if ( $usermeta ) {
 					foreach ( $usermeta as $metakey => $metavalue ) {
+						// If the value of the meta key is empty, lets not do anything but skip it.
+						if ( empty( $metavalue ) ) {
+							continue;
+						}
+
 						$metavalue = maybe_unserialize( $metavalue );
 						update_user_meta( $user_id, $metakey, $metavalue );
 					}


### PR DESCRIPTION
* ENHANCEMENT: This now skips user meta fields when the value is empty.

Before this patch, if you had an empty column for a custom field it would set the value to '' and not delete the user meta. This now helps add support for multiple membership levels per user and importing and in cases where you might have entered user meta for the first instance of the import but not on the duplicate rows for the other membership levels.