### PR TITLE
Allow importing of "0" values

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -621,7 +621,7 @@ class PMPro_Import_Users_From_CSV {
 				if ( $usermeta ) {
 					foreach ( $usermeta as $metakey => $metavalue ) {
 						// If the value of the meta key is empty, lets not do anything but skip it.
-						if ( empty( $metavalue ) ) {
+						if ( empty( $metavalue ) && $metavalue !== '0' ) {
 							continue;
 						}
 


### PR DESCRIPTION
* Allowing to import "0" values when importing data. This helps skip completely missing values but will allow you to import "0" values for user meta.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-import-users-from-csv/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-import-users-from-csv/pulls) for the same update/change?