### PR TITLE
Trims user meta keys on import

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -518,7 +518,7 @@ class PMPro_Import_Users_From_CSV {
 
 			// If we are on the first line, the columns are the headers
 			if ( $first ) {
-				$headers = $line;
+				$headers = array_map( 'trim', $line );
 				$first   = false;
 
 				// skip ahead for partial imports
@@ -626,7 +626,7 @@ class PMPro_Import_Users_From_CSV {
 						}
 
 						$metavalue = maybe_unserialize( $metavalue );
-						update_user_meta( $user_id, trim( $metakey ), $metavalue );
+						update_user_meta( $user_id, $metakey, $metavalue );
 					}
 				}
 


### PR DESCRIPTION
Trims keys to avoid any unexpected whitespace from CSV files

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-import-users-from-csv/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-import-users-from-csv/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Trims user meta keys that originate from CSV files

### How to test the changes in this Pull Request:

1. Edit a CSV file and add a space after a column name that would be used as user meta
2. Run the import. This should set the key to the value without spaces

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

