### PR TITLE
Maintain Row Numbers in Error Log

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -570,10 +570,11 @@ class PMPro_Import_Users_From_CSV {
 			// delete file
 			unlink( $import_dir . $filename );
 
-			// delete position, mapping, and error transients
+			// delete position, mapping, error, and row offset transients
 			delete_transient( 'pmproiucsv_' . $filename );
 			delete_transient( 'pmproiucsv_map_' . $filename );
 			delete_transient( 'pmproiucsv_errors_' . $filename );
+			delete_transient( 'pmproiucsv_rowoffset_' . $filename );
 		}
 
 		// Some users imported?
@@ -651,6 +652,16 @@ class PMPro_Import_Users_From_CSV {
 
 		$first = true;
 		$rkey  = 0;
+
+		// For partial/batched imports, resume the absolute row counter from previous batches
+		// so that error log line numbers reflect the true position in the file.
+		if ( ! empty( $partial ) ) {
+			$saved_row_offset = get_transient( 'pmproiucsv_rowoffset_' . basename( $filename ) );
+			if ( $saved_row_offset !== false ) {
+				$rkey = (int) $saved_row_offset;
+			}
+		}
+
 		while ( ( $line = $csv_reader->get_row() ) !== null ) {
 
 			// If the first line is empty, abort
@@ -833,6 +844,7 @@ class PMPro_Import_Users_From_CSV {
 			if ( ! empty( $partial ) && $rkey ) {
 				$position = $csv_reader->get_position();
 				set_transient( 'pmproiucsv_' . basename( $filename ), $position, DAY_IN_SECONDS * 2 );
+				set_transient( 'pmproiucsv_rowoffset_' . basename( $filename ), $rkey, DAY_IN_SECONDS * 2 );
 
 				if ( $rkey > $per_partial - 1 ) {
 					break;

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -413,6 +413,7 @@ class PMPro_Import_Users_From_CSV {
 				// resetting position transients?
 				if ( ! empty( $_REQUEST['reset'] ) ) {
 					delete_transient( 'pmproiucsv_' . $filename );
+					delete_transient( 'pmproiucsv_rowoffset_' . $filename );
 				}
 				?>
 				<div id="pmproiucsv_result" style="display:none;"></div>
@@ -650,11 +651,13 @@ class PMPro_Import_Users_From_CSV {
 		$file_handle = fopen( $filename, 'r' );
 		$csv_reader  = new ReadCSV( $file_handle, PMPROIUCSV_CSV_DELIMITER, "\xEF\xBB\xBF" ); // Skip any UTF-8 byte order mark.
 
-		$first = true;
-		$rkey  = 0;
+		$first       = true;
+		$rkey        = 0;
+		$batch_count = 0;
 
 		// For partial/batched imports, resume the absolute row counter from previous batches
-		// so that error log line numbers reflect the true position in the file.
+		// so that error log line numbers reflect the true position in the file. $batch_count
+		// stays at 0 each batch so the per-batch break limit ($per_partial) still applies.
 		if ( ! empty( $partial ) ) {
 			$saved_row_offset = get_transient( 'pmproiucsv_rowoffset_' . basename( $filename ) );
 			if ( $saved_row_offset !== false ) {
@@ -743,6 +746,7 @@ class PMPro_Import_Users_From_CSV {
 				$error = new WP_Error( 'invalid_email', $error_message );
 				$errors[ $rkey ] = $error;
 				$rkey++;
+				$batch_count++;
 				continue;
 			}
 
@@ -839,14 +843,15 @@ class PMPro_Import_Users_From_CSV {
 			}
 
 			$rkey++;
+			$batch_count++;
 
 			// if doing a partial import, save our spot and break
-			if ( ! empty( $partial ) && $rkey ) {
+			if ( ! empty( $partial ) && $batch_count ) {
 				$position = $csv_reader->get_position();
 				set_transient( 'pmproiucsv_' . basename( $filename ), $position, DAY_IN_SECONDS * 2 );
 				set_transient( 'pmproiucsv_rowoffset_' . basename( $filename ), $rkey, DAY_IN_SECONDS * 2 );
 
-				if ( $rkey > $per_partial - 1 ) {
+				if ( $batch_count > $per_partial - 1 ) {
 					break;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-import-users-from-csv/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-import-users-from-csv/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Due to members being imported into batches, any errors related to a specific line end up being tied to a batch. This means that an issue in batch 1 on line 3 and a new error in batch 8 on line 3 both reference line 3. 

This PR fixes this and ensures that the original file's lines are referenced:

```
BEGIN 2026-04-09 15:06:22
[Line 23] Sorry, that username already exists!
BEGIN 2026-04-09 15:06:57
[Line 66] Sorry, that username already exists!
```

### How to test the changes in this Pull Request:

1. Create a file with multiple errors in it spread out across what would be multiple batches (default is 50)
2. Run a test import with either more than 50 records or reduce the batch size 
3. The errors should reference the original file lines

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
