### PR TITLE
Pad imported enddate to end of day to prevent expiring users a day early

### DIFF
--- a/includes/pmpro-membership-data.php
+++ b/includes/pmpro-membership-data.php
@@ -117,7 +117,13 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 	}
 
 	if ( ! empty( $membership_enddate ) ) {
-		$membership_enddate = date( 'Y-m-d', strtotime( $membership_enddate, current_time( 'timestamp' ) ) );
+		// If the CSV value did not include an explicit time, pad to end-of-day so the user keeps
+		// access through the final day, matching PMPro core checkout behavior (includes/checkout.php).
+		// Otherwise the row is stored with 00:00:00 and the daily expiration cron cancels the user
+		// at the start of that day — effectively a day early.
+		$enddate_has_time   = (bool) preg_match( '/\d{1,2}:\d{2}/', $membership_enddate );
+		$enddate_format     = $enddate_has_time ? 'Y-m-d H:i:s' : 'Y-m-d 23:59:59';
+		$membership_enddate = date( $enddate_format, strtotime( $membership_enddate, current_time( 'timestamp' ) ) );
 	} else {
 		$membership_enddate = '';
 	}


### PR DESCRIPTION
## Summary

When importing users via CSV, the `membership_enddate` value is stored in `wp_pmpro_memberships_users.enddate` with a `00:00:00` time component. PMPro's daily `pmpro_cron_expire_memberships` cron then cancels those users the first time it runs on that date — typically shortly after midnight — instead of after the final day ends. From an admin's perspective, imported users appear to expire **one full day earlier than the date they put in the spreadsheet**.

This is inconsistent with PMPro core: in `paid-memberships-pro/includes/checkout.php` non-hourly checkouts pad the end date to `23:59:59`, so customers who sign up through the normal flow get their full final day. Only imported users are affected.

## Root cause

`includes/pmpro-membership-data.php:120`:

```php
$membership_enddate = date( 'Y-m-d', strtotime( $membership_enddate, current_time( 'timestamp' ) ) );
```

`date('Y-m-d', ...)` strips any time portion. When that string lands in a `DATETIME` column, MySQL fills the time as `00:00:00`.

## How the cron then expires them early

`paid-memberships-pro/scheduled/crons.php`:

```php
$today = date("Y-m-d H:i:00", current_time("timestamp"));

SELECT ... WHERE mu.status = 'active' AND mu.enddate <= '$today' ...
```

For a row stored as `2026-05-31 00:00:00`, the very first cron run on `2026-05-31` satisfies `'2026-05-31 00:00:00' <= '2026-05-31 HH:MM:00'` and the membership is cancelled with status `expired`, even though both the admin and the customer understood the membership to run *through* `2026-05-31`.

## Fix

Pad date-only CSV values to `23:59:59` so imported users behave the same as users created through PMPro core's checkout. CSV values that already include an explicit time component are preserved.

```php
if ( ! empty( $membership_enddate ) ) {
    $enddate_has_time   = (bool) preg_match( '/\d{1,2}:\d{2}/', $membership_enddate );
    $enddate_format     = $enddate_has_time ? 'Y-m-d H:i:s' : 'Y-m-d 23:59:59';
    $membership_enddate = date( $enddate_format, strtotime( $membership_enddate, current_time( 'timestamp' ) ) );
} else {
    $membership_enddate = '';
}
```

The existing past/future comparisons at lines 193 and 200 still work because they re-parse `$membership_enddate` with `strtotime()`.

## Remediation for sites that have already imported

For sites running the current code, the following SQL re-pads existing midnight end dates to end of day:

```sql
UPDATE wp_pmpro_memberships_users
   SET enddate = DATE_FORMAT(enddate, '%Y-%m-%d 23:59:59')
 WHERE status = 'active'
   AND enddate IS NOT NULL
   AND DATE_FORMAT(enddate, '%H:%i:%s') = '00:00:00';
```

(Recommend running a `SELECT` version first to verify scope.)

## Test plan

- [ ] Import a CSV with `membership_enddate=YYYY-MM-DD` (no time). Confirm the row in `wp_pmpro_memberships_users` has `enddate` ending in `23:59:59`.
- [ ] Import a CSV with `membership_enddate=YYYY-MM-DD HH:MM:SS`. Confirm the explicit time is preserved.
- [ ] Set the imported `enddate` to today, run `pmpro_cron_expire_memberships`, and confirm the user is **not** expired until after end-of-day.
- [ ] Re-import an existing member with a blank `membership_enddate`; confirm the enddate is cleared (existing behavior preserved).