### PR TITLE
Fix ID field not auto-mapping on the CSV import screen

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -255,7 +255,7 @@ class PMPro_Import_Users_From_CSV {
 		}
 
 		// Ensure all required fields are mapped before proceeding.
-		$required_fields = apply_filters( 'pmproiucsv_required_import_headers', array( 'user_email' ) );
+		$required_fields = apply_filters( 'pmproiucsv_required_import_headers', array() );
 		$mapped_values   = array_values( $field_map );
 		foreach ( $required_fields as $required_field ) {
 			if ( ! in_array( $required_field, $mapped_values, true ) ) {
@@ -267,6 +267,18 @@ class PMPro_Import_Users_From_CSV {
 					)
 				);
 			}
+		}
+
+		// At least one identifying field must be mapped so users can be created and/or matched.
+		$identifier_fields = apply_filters( 'pmproiucsv_identifier_import_headers', array( 'user_email', 'user_login', 'ID' ) );
+		if ( ! array_intersect( $identifier_fields, $mapped_values ) ) {
+			wp_die(
+				sprintf(
+					/* translators: %s: comma-separated list of identifier field names */
+					esc_html__( 'Import cancelled: at least one identifying field must be mapped to a column before importing (%s).', 'pmpro-import-users-from-csv' ),
+					esc_html( implode( ', ', $identifier_fields ) )
+				)
+			);
 		}
 
 		// Verify the file exists before storing the mapping transient.

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -957,17 +957,18 @@ class PMPro_Import_Users_From_CSV {
 	public static function auto_detect_field( $header ) {
 		$header_lower = strtolower( trim( $header ) );
 
-		// Build flat list of all known field keys.
+		// Map of lowercased field key => canonical field key (e.g. 'id' => 'ID').
 		$all_field_keys = array();
 		foreach ( self::get_mapping_fields() as $group ) {
 			foreach ( $group['fields'] as $key => $label ) {
-				$all_field_keys[] = strtolower( $key );
+				$all_field_keys[ strtolower( $key ) ] = $key;
 			}
 		}
 
 		// Direct match (CSV column already uses the field key, e.g. "user_email").
-		if ( in_array( $header_lower, $all_field_keys, true ) ) {
-			return $header_lower;
+		// Return the canonical key so mixed-case keys like 'ID' map correctly.
+		if ( isset( $all_field_keys[ $header_lower ] ) ) {
+			return $all_field_keys[ $header_lower ];
 		}
 
 		/**
@@ -979,6 +980,8 @@ class PMPro_Import_Users_From_CSV {
 		 * @param array $aliases An array of column header aliases and the field type.
 		 */
 		$aliases = apply_filters( 'pmproiucsv_field_aliases', array(
+			'user_id'          => 'ID',
+			'user id'          => 'ID',
 			'email'            => 'user_email',
 			'e-mail'           => 'user_email',
 			'mail'             => 'user_email',


### PR DESCRIPTION
## Summary
- `auto_detect_field()` lowercases both the CSV header and the field keys to compare them, but on a match it returned the lowercased header string instead of the canonical field key. `ID` is the only mixed-case key in `get_mapping_fields()`, so it's the only one this broke: a CSV column named `ID`/`id` would resolve to `'id'`, which doesn't match the dropdown's `<option value="ID">` under the case-sensitive `selected()` check, so it never auto-selected on the mapping screen.
- Added `user_id` / `user id` as header aliases for `ID`, since that's the column name this plugin's own export produces — CSVs round-tripped from an export now map correctly with zero manual configuration.

## Context
Surfaced by a customer doing large recurring member imports (60-70 files/year) who wants to auto-map by `ID` instead of falling back to email match, since re-mapping columns for every file isn't feasible at that volume and email isn't a reliable identifier across years of data (emails change).

## Test plan
- [x] `php -l` on the changed file
- [ ] Upload a CSV with an `ID` column and confirm "User ID" is preselected on the mapping screen
- [ ] Upload a CSV with a `user_id` column and confirm it also preselects "User ID" via the new alias
- [ ] Confirm existing users are matched/updated by ID rather than creating duplicates
