### PR TITLE
Fix case-sensitive direct match in auto_detect_field()

### DIFF
--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -957,17 +957,18 @@ class PMPro_Import_Users_From_CSV {
 	public static function auto_detect_field( $header ) {
 		$header_lower = strtolower( trim( $header ) );
 
-		// Build flat list of all known field keys.
+		// Build a map of lowercased field key => original-case field key.
 		$all_field_keys = array();
 		foreach ( self::get_mapping_fields() as $group ) {
 			foreach ( $group['fields'] as $key => $label ) {
-				$all_field_keys[] = strtolower( $key );
+				$all_field_keys[ strtolower( $key ) ] = $key;
 			}
 		}
 
 		// Direct match (CSV column already uses the field key, e.g. "user_email").
-		if ( in_array( $header_lower, $all_field_keys, true ) ) {
-			return $header_lower;
+		// Return the original-case key (e.g. "ID") so it matches the mapping dropdown's option value.
+		if ( isset( $all_field_keys[ $header_lower ] ) ) {
+			return $all_field_keys[ $header_lower ];
 		}
 
 		/**


### PR DESCRIPTION
## Summary
- `auto_detect_field()` builds `$all_field_keys` by lowercasing each field key, then does a case-insensitive membership check, but returns the lowercased header on a match instead of the original-case key.
- This breaks auto-selection for any field key that isn't already all-lowercase (e.g. the `ID` field key). A CSV column named `id`/`ID` resolves to `id`, which fails the strict `selected()` comparison against the actual option value `ID`, so the mapping dropdown never auto-selects.
- Fix: build the lookup as lowercased key => original-case key, and return the original-case key on direct match.

## Test plan
- [ ] Upload a CSV with a column header `id` (or `ID`) and confirm it auto-maps to "User ID" in the field mapping screen.
- [ ] Confirm existing lowercase-key columns (e.g. `user_email`) still auto-map correctly.
- [ ] Confirm the `pmproiucsv_field_aliases` filter still works for non-direct-match headers (e.g. `user_id` -> `ID`).
