### PR TITLE
Include membership timestamp in order saving

### DIFF
--- a/includes/pmpro-membership-data.php
+++ b/includes/pmpro-membership-data.php
@@ -129,9 +129,10 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 	}
 
 	if ( ! empty( $membership_timestamp ) ) {
-		$membership_timestamp = date( 'Y-m-d H:i:s', strtotime($membership_timestamp, current_time( 'timestamp' ) ) );
+		// Order timestamps are stored in GMT, so convert the local CSV value before saving.
+		$membership_timestamp = (int) get_gmt_from_date( date( 'Y-m-d H:i:s', strtotime( $membership_timestamp, current_time( 'timestamp' ) ) ), 'U' );
 	} else {
-		$membership_timestamp = current_time( 'mysql' );
+		$membership_timestamp = '';
 	}
 
 	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) ) {
@@ -294,7 +295,9 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 		$order->status = $order_status;
 		$order->subtotal = $membership_initial_payment;
 		$order->total = $membership_initial_payment;
-		$order->timestamp = $membership_timestamp; // If empty defaults to time of import.
+		if ( ! empty( $membership_timestamp ) ) {
+			$order->timestamp = $membership_timestamp;
+		} // If empty, saveOrder() defaults to time of import.
 
 		$order->saveOrder();
 	} else {

--- a/includes/pmpro-membership-data.php
+++ b/includes/pmpro-membership-data.php
@@ -293,14 +293,23 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 		$order->subtotal = $membership_initial_payment;
 		$order->total = $membership_initial_payment;
 
-		$order->saveOrder();
+		if(!empty($membership_timestamp))
+		{
+			$timestamp = strtotime($membership_timestamp, current_time('timestamp'));
+			$order->timestamp = $timestamp;
+		}
 
+		$order->saveOrder();
+		/*
+		// The updateTimestamp method should not be used any more, per class.mmberorder.php and, in fact, it doesn't work.
 		// Maybe update timestamp of order if the import includes the membership_timestamp.
+		// Move the code up.
 		if(!empty($membership_timestamp))
 		{
 			$timestamp = strtotime($membership_timestamp, current_time('timestamp'));
 			$order->updateTimeStamp(date("Y", $timestamp), date("m", $timestamp), date("d", $timestamp), date("H:i:s", $timestamp));
 		}
+		*/
 	} else {
 		$order = null; // No order created, so set to null for the action below.
 	}

--- a/includes/pmpro-membership-data.php
+++ b/includes/pmpro-membership-data.php
@@ -111,7 +111,7 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 
 	// Fix date formats.
 	if ( ! empty( $membership_startdate ) ) {
-		$membership_startdate = date( 'Y-m-d', strtotime( $membership_startdate, current_time( 'timestamp' ) ) );
+		$membership_startdate = date( 'Y-m-d H:i:s', strtotime( $membership_startdate, current_time( 'timestamp' ) ) );
 	} else {
 		$membership_startdate = current_time( 'mysql' );
 	}
@@ -129,7 +129,9 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 	}
 
 	if ( ! empty( $membership_timestamp ) ) {
-		$membership_timestamp = date( 'Y-m-d', strtotime($membership_timestamp, current_time( 'timestamp' ) ) );
+		$membership_timestamp = date( 'Y-m-d H:i:s', strtotime($membership_timestamp, current_time( 'timestamp' ) ) );
+	} else {
+		$membership_timestamp = current_time( 'mysql' );
 	}
 
 	if ( ! empty( $membership_discount_code ) && empty( $membership_code_id ) ) {
@@ -292,24 +294,9 @@ function pmproiucsv_is_iu_post_user_import($user_id)
 		$order->status = $order_status;
 		$order->subtotal = $membership_initial_payment;
 		$order->total = $membership_initial_payment;
-
-		if(!empty($membership_timestamp))
-		{
-			$timestamp = strtotime($membership_timestamp, current_time('timestamp'));
-			$order->timestamp = $timestamp;
-		}
+		$order->timestamp = $membership_timestamp; // If empty defaults to time of import.
 
 		$order->saveOrder();
-		/*
-		// The updateTimestamp method should not be used any more, per class.mmberorder.php and, in fact, it doesn't work.
-		// Maybe update timestamp of order if the import includes the membership_timestamp.
-		// Move the code up.
-		if(!empty($membership_timestamp))
-		{
-			$timestamp = strtotime($membership_timestamp, current_time('timestamp'));
-			$order->updateTimeStamp(date("Y", $timestamp), date("m", $timestamp), date("d", $timestamp), date("H:i:s", $timestamp));
-		}
-		*/
 	} else {
 		$order = null; // No order created, so set to null for the action below.
 	}


### PR DESCRIPTION
Add timestamp to order if membership_timestamp is provided.  The updateTimeStamp method of the order lass doesn't seem to work any more.

### All Submissions:

* [?] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-import-users-from-csv/blob/master/.github/CONTRIBUTING.md)?
* [?] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-import-users-from-csv/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Move the code in **pmproiucsv_is_iu_post_user_import** that sets an order timestamp to before the saveOrder call instead of using the order's updateTimeStamp method afterwards.   This fixes the issue that the update to the value doesn't currently work and is also compliant with instructions in the MemberOrder class not to use that method.

### How to test the changes in this Pull Request:

1. Create an import CSV file that sets a timestamp explicitly.  The delivered sample file will do IF you add a membership_code_id column, since otherwise an order will not be created.
2. Upload the test file and check the order dates.
3. Make the change, upload again, check again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> comment out current derivation of order->timestamp and call to updateTimestamp , add direct setting of order->timestamp before the call to order->saveOrder().
