### PR TITLE
Add nonce and capability checks to the import AJAX endpoint

### DIFF
--- a/includes/ajaximport.js
+++ b/includes/ajaximport.js
@@ -37,7 +37,7 @@ jQuery(document).ready(function () {
             jQuery.ajax({
                 url: ajaxurl, type: 'GET', timeout: 30000,
                 dataType: 'html',
-                data: 'action=pmpro_import_users_from_csv&filename=' + ai_filename + '&users_update=' + ai_users_update + '&new_user_notification=' + ai_new_user_notification,
+                data: 'action=pmpro_import_users_from_csv&filename=' + ai_filename + '&users_update=' + ai_users_update + '&new_user_notification=' + ai_new_user_notification + '&_ajax_nonce=' + ai_nonce,
                 error: function (xml) {
                     alert('Error with import. Try refreshing.');
                     jQuery('#pmproiucsv_return_home').show();

--- a/includes/ajaximport.js
+++ b/includes/ajaximport.js
@@ -48,6 +48,11 @@ jQuery(document).ready(function () {
                         document.title = $title;
                         jQuery('#pmproiucsv_return_home').show();
                     }
+                    else if (responseHTML == 'noperm') {
+                        $status.html($status.html() + '\nYou do not have permission to run this import. The import has stopped.\n');
+                        document.title = $title;
+                        jQuery('#pmproiucsv_return_home').show();
+                    }
                     else if (responseHTML == 'nofile') {
                         $status.html($status.html() + '\nCould not find the file ' + ai_filename + '. Maybe it has already been imported.');
                         document.title = $title;

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -447,6 +447,7 @@ class PMPro_Import_Users_From_CSV {
 							var ai_filename = <?php echo json_encode( $filename ); ?>;
 							var ai_users_update = <?php echo json_encode( $users_update ); ?>;
 							var ai_new_user_notification = <?php echo json_encode( $new_user_notification ); ?>;
+							var ai_nonce = <?php echo json_encode( wp_create_nonce( 'pmproiucsv_import' ) ); ?>;
 							var ai_error_log_url = <?php echo json_encode( self::$log_dir_url ); ?>;
 						</script>
 					</div> <!-- end pmpro_section_inside -->
@@ -522,6 +523,14 @@ class PMPro_Import_Users_From_CSV {
 	 * @since ?
 	 */
 	public static function wp_ajax_pmpro_import_users_from_csv() {
+		// Check the nonce.
+		check_ajax_referer( 'pmproiucsv_import' );
+
+		// Check for capability.
+		if ( ! current_user_can( 'create_users' ) ) {
+			die( 'You do not have permission to import users.' );
+		}
+
 		// check for filename
 		if ( empty( $_REQUEST['filename'] ) ) {
 			die( 'No file name given.' );

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -528,7 +528,7 @@ class PMPro_Import_Users_From_CSV {
 
 		// Check for capability.
 		if ( ! current_user_can( 'create_users' ) ) {
-			die( 'You do not have permission to import users.' );
+			die( 'noperm' );
 		}
 
 		// check for filename


### PR DESCRIPTION
The `wp_ajax_pmpro_import_users_from_csv` endpoint (the partial-import worker that processes the CSV in batches) did not perform the permission checks used by the plugin's other import handlers (upload, mapping, and cancel all use `check_admin_referer()` + `current_user_can( 'create_users' )`).

This PR brings the AJAX worker in line with the rest of the import flow:

- Verifies a nonce (`pmproiucsv_import`) passed from the import progress screen.
- Requires the `create_users` capability before processing.

**Testing:** run a CSV import and confirm batches still process and complete. Reload the progress page after the nonce expires (or tamper with it) and confirm the import halts instead of processing.