### PR TITLE
Carry the Skip Existing Members flag through to the AJAX import

### DIFF
--- a/includes/ajaximport.js
+++ b/includes/ajaximport.js
@@ -37,7 +37,7 @@ jQuery(document).ready(function () {
             jQuery.ajax({
                 url: ajaxurl, type: 'GET', timeout: 30000,
                 dataType: 'html',
-                data: 'action=pmpro_import_users_from_csv&filename=' + ai_filename + '&users_update=' + ai_users_update + '&new_user_notification=' + ai_new_user_notification + '&_ajax_nonce=' + ai_nonce,
+                data: 'action=pmpro_import_users_from_csv&filename=' + ai_filename + '&users_update=' + ai_users_update + '&new_user_notification=' + ai_new_user_notification + '&skip_existing_members_same_level=' + ai_skip_existing_members_same_level + '&_ajax_nonce=' + ai_nonce,
                 error: function (xml) {
                     alert('Error with import. Try refreshing.');
                     jQuery('#pmproiucsv_return_home').show();

--- a/pmpro-import-users-from-csv.php
+++ b/pmpro-import-users-from-csv.php
@@ -140,6 +140,7 @@ class PMPro_Import_Users_From_CSV {
 
 		$users_update          = isset( $_REQUEST['users_update'] ) ? $_REQUEST['users_update'] : false;
 		$new_user_notification = isset( $_REQUEST['new_user_notification'] ) ? $_REQUEST['new_user_notification'] : false;
+		$skip_existing_members_same_level = isset( $_REQUEST['skip_existing_members_same_level'] ) ? $_REQUEST['skip_existing_members_same_level'] : false;
 
 		// Always save the uploaded file so we can read headers on the mapping screen.
 		$import_dir = self::$import_dir_path;
@@ -215,6 +216,7 @@ class PMPro_Import_Users_From_CSV {
 				'filename'              => $filename,
 				'users_update'          => $users_update,
 				'new_user_notification' => $new_user_notification,
+				'skip_existing_members_same_level' => $skip_existing_members_same_level,
 			),
 			admin_url( 'users.php' )
 		);
@@ -243,6 +245,7 @@ class PMPro_Import_Users_From_CSV {
 		$filename              = sanitize_file_name( wp_unslash( $_REQUEST['filename'] ) );
 		$users_update          = isset( $_REQUEST['users_update'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['users_update'] ) ) : false;
 		$new_user_notification = isset( $_REQUEST['new_user_notification'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['new_user_notification'] ) ) : false;
+		$skip_existing_members_same_level = isset( $_REQUEST['skip_existing_members_same_level'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['skip_existing_members_same_level'] ) ) : false;
 
 		$field_map = array();
 
@@ -288,6 +291,7 @@ class PMPro_Import_Users_From_CSV {
 				'filename'              => $filename,
 				'users_update'          => $users_update,
 				'new_user_notification' => $new_user_notification,
+				'skip_existing_members_same_level' => $skip_existing_members_same_level,
 			),
 			admin_url( 'users.php' )
 		);
@@ -409,6 +413,7 @@ class PMPro_Import_Users_From_CSV {
 				$filename              = sanitize_file_name( $_REQUEST['filename'] );
 				$users_update          = isset( $_REQUEST['users_update'] ) ? $_REQUEST['users_update'] : false;
 				$new_user_notification = isset( $_REQUEST['new_user_notification'] ) ? $_REQUEST['new_user_notification'] : false;
+				$skip_existing_members_same_level = isset( $_REQUEST['skip_existing_members_same_level'] ) ? $_REQUEST['skip_existing_members_same_level'] : '';
 
 				// resetting position transients?
 				if ( ! empty( $_REQUEST['reset'] ) ) {
@@ -447,6 +452,7 @@ class PMPro_Import_Users_From_CSV {
 							var ai_filename = <?php echo json_encode( $filename ); ?>;
 							var ai_users_update = <?php echo json_encode( $users_update ); ?>;
 							var ai_new_user_notification = <?php echo json_encode( $new_user_notification ); ?>;
+							var ai_skip_existing_members_same_level = <?php echo json_encode( $skip_existing_members_same_level ); ?>;
 							var ai_nonce = <?php echo json_encode( wp_create_nonce( 'pmproiucsv_import' ) ); ?>;
 							var ai_error_log_url = <?php echo json_encode( self::$log_dir_url ); ?>;
 						</script>
@@ -1079,6 +1085,7 @@ class PMPro_Import_Users_From_CSV {
 		$filename              = sanitize_file_name( wp_unslash( $_REQUEST['filename'] ) );
 		$users_update          = isset( $_REQUEST['users_update'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['users_update'] ) ) : '';
 		$new_user_notification = isset( $_REQUEST['new_user_notification'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['new_user_notification'] ) ) : '';
+		$skip_existing_members_same_level = isset( $_REQUEST['skip_existing_members_same_level'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['skip_existing_members_same_level'] ) ) : '';
 
 		$csv_data = self::get_csv_sample_data( $filename );
 		$headers  = $csv_data['headers'];
@@ -1124,6 +1131,7 @@ class PMPro_Import_Users_From_CSV {
 					<input type="hidden" name="filename"              value="<?php echo esc_attr( $filename ); ?>">
 					<input type="hidden" name="users_update"          value="<?php echo esc_attr( $users_update ); ?>">
 					<input type="hidden" name="new_user_notification" value="<?php echo esc_attr( $new_user_notification ); ?>">
+					<input type="hidden" name="skip_existing_members_same_level" value="<?php echo esc_attr( $skip_existing_members_same_level ); ?>">
 
 					<table class="widefat striped" id="pmproiucsv-mapping-table">
 						<thead>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-import-users-from-csv/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-import-users-from-csv/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The guard in `pmproiucsv_is_iu_post_user_import()` reads `$_REQUEST['skip_existing_members_same_level']`, but the checkbox value was dropped at the first redirect and never included in the AJAX request, so the guard could never fire. Matching-level imports always re-ran `pmpro_changeMembershipLevel()`, resetting `startdate`, wiping `enddate`, and blanking the billing fields even when the box was checked.

Plumb the flag through the map and resume redirects, the mapping-screen hidden fields, and the AJAX data string, matching how `users_update` and `new_user_notification` are already handled.

The resume-screen fallback is `''` rather than `false` because the value is `json_encode`'d into a JS variable and concatenated into the query string; `false` would arrive as the truthy string `"false"` and enable skipping for an admin who never checked the box.

Note: WP-CLI imports still do not honor this option, since `$_REQUEST` is empty under CLI and there is no flag to carry. Out of scope here.

### How to test the changes in this Pull Request:

1. Create a member and give them a membership level. Note their level's start date, expiration date, and the row in `wp_pmpro_memberships_users` (`id`, `startdate`, `enddate`, `status`).
2. Build a CSV containing that member's `user_email` and a `membership_id` matching their **current** level. Do **not** include `membership_startdate` or `membership_enddate` columns.
3. Go to **Users > Import Members From CSV**, upload the CSV, check **Skip Existing Members**, and complete the field mapping.
4. After the import finishes, re-check `wp_pmpro_memberships_users`. Expected: the member's existing row is untouched (same `id`, same `startdate`, same `enddate`, still `active`) and **no new row was inserted**. Before this patch, the old row was deactivated and a new row was inserted with today's `startdate`, an empty `enddate`, and blanked billing fields.
5. Repeat the same import with **Skip Existing Members** left unchecked. Expected: the level change proceeds exactly as before this patch — a new row is inserted and the previous one is deactivated. This confirms skipping did not become the default.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

BUG FIX: Fixed an issue where the "Skip Existing Members" option had no effect. Importing a member with a `membership_id` matching their current level would reset their start date, clear their expiration date, and blank their billing fields even when the option was checked.
